### PR TITLE
Tweak CSS in MatchPlayer

### DIFF
--- a/client/src/components/MatchPlayer/MatchPlayer.scss
+++ b/client/src/components/MatchPlayer/MatchPlayer.scss
@@ -14,11 +14,12 @@
     position: absolute;
     top: 0;
     right: 0;
-    transform: translate(15%, -25%) rotateZ(15deg);
+    transform: translate(20%, -40%) rotateZ(15deg);
   }
 
   &__image {
     display: block;
+    object-fit: cover;
     height: 2.5rem;
     width: 2.5rem;
     border-radius: 50%;
@@ -32,7 +33,6 @@
 
   &__points {
     margin-left: auto;
-    color: $background;
-    text-shadow: 0 0 2px $text;
+    color: $text-light;
   }
 }

--- a/client/src/styles/_colors.scss
+++ b/client/src/styles/_colors.scss
@@ -1,4 +1,5 @@
 $text: #0b0a01;
+$text-light: #6c6c68;
 $background: #fdfdef;
 $primary: #e6da1f;
 $secondary: #b5f28b;


### PR DESCRIPTION
- Make points text more visible
- Object-fit: cover for player icons that are non-square
- Place crown a bit higher