### PR TITLE
Fix GamePicker animation bug in Safari

### DIFF
--- a/client/src/components/GamePicker/GamePicker.jsx
+++ b/client/src/components/GamePicker/GamePicker.jsx
@@ -22,7 +22,7 @@ export default function GamePicker({ onChange, value, children }) {
   const hasChildren = Children.toArray(children).some((child) => !!child);
 
   return (
-    <div className={"game-picker"}>
+    <div className="game-picker">
       {games.map((game, i) => (
         <div
           className={`game-picker-item ${

--- a/client/src/components/GamePicker/GamePicker.jsx
+++ b/client/src/components/GamePicker/GamePicker.jsx
@@ -1,15 +1,30 @@
 import "./GamePicker.scss";
 import useAxios from "../../hooks/useAxios";
-import { useState, Children } from "react";
+import { useState, Children, useEffect } from "react";
 
 export default function GamePicker({ onChange, value, children }) {
   const [games, loading, error] = useAxios("/games");
   const [topOfStack, setTopOfStack] = useState(0);
+  const [hideChildren, setHideChildren] = useState(false);
 
   const handleChange = (game, i) => {
     onChange(game);
     setTopOfStack(i);
   };
+
+  const hasChildren = Children.toArray(children).some((child) => !!child);
+
+  useEffect(() => {
+    let timeout;
+
+    if (hasChildren) {
+      timeout = setTimeout(() => setHideChildren(false), 100);
+    } else {
+      setHideChildren(true);
+    }
+
+    return () => clearTimeout(timeout);
+  }, [hasChildren]);
 
   if (loading) {
     return <></>;
@@ -18,8 +33,6 @@ export default function GamePicker({ onChange, value, children }) {
   if (error) {
     return <div>Error: {error.message}</div>;
   }
-
-  const hasChildren = Children.toArray(children).some((child) => !!child);
 
   return (
     <div className={`game-picker ${value ? "game-picker--done" : ""}`}>
@@ -57,7 +70,7 @@ export default function GamePicker({ onChange, value, children }) {
         </div>
       ))}
 
-      {hasChildren && <div className="game-picker__children">{children}</div>}
+      {!hideChildren && <div className="game-picker__children">{children}</div>}
     </div>
   );
 }

--- a/client/src/components/GamePicker/GamePicker.jsx
+++ b/client/src/components/GamePicker/GamePicker.jsx
@@ -11,8 +11,6 @@ export default function GamePicker({ onChange, value, children }) {
     setTopOfStack(i);
   };
 
-  const hasChildren = Children.toArray(children).some((child) => !!child);
-
   if (loading) {
     return <></>;
   }
@@ -20,6 +18,8 @@ export default function GamePicker({ onChange, value, children }) {
   if (error) {
     return <div>Error: {error.message}</div>;
   }
+
+  const hasChildren = Children.toArray(children).some((child) => !!child);
 
   return (
     <div className={"game-picker"}>

--- a/client/src/components/GamePicker/GamePicker.jsx
+++ b/client/src/components/GamePicker/GamePicker.jsx
@@ -1,11 +1,10 @@
 import "./GamePicker.scss";
 import useAxios from "../../hooks/useAxios";
-import { useState, Children, useEffect } from "react";
+import { useState, Children } from "react";
 
 export default function GamePicker({ onChange, value, children }) {
   const [games, loading, error] = useAxios("/games");
   const [topOfStack, setTopOfStack] = useState(0);
-  const [hideChildren, setHideChildren] = useState(false);
 
   const handleChange = (game, i) => {
     onChange(game);
@@ -13,18 +12,6 @@ export default function GamePicker({ onChange, value, children }) {
   };
 
   const hasChildren = Children.toArray(children).some((child) => !!child);
-
-  useEffect(() => {
-    let timeout;
-
-    if (hasChildren) {
-      timeout = setTimeout(() => setHideChildren(false), 100);
-    } else {
-      setHideChildren(true);
-    }
-
-    return () => clearTimeout(timeout);
-  }, [hasChildren]);
 
   if (loading) {
     return <></>;
@@ -35,7 +22,7 @@ export default function GamePicker({ onChange, value, children }) {
   }
 
   return (
-    <div className={`game-picker ${value ? "game-picker--done" : ""}`}>
+    <div className={"game-picker"}>
       {games.map((game, i) => (
         <div
           className={`game-picker-item ${
@@ -70,7 +57,7 @@ export default function GamePicker({ onChange, value, children }) {
         </div>
       ))}
 
-      {!hideChildren && <div className="game-picker__children">{children}</div>}
+      {hasChildren && <div className="game-picker__children">{children}</div>}
     </div>
   );
 }

--- a/client/src/components/GamePicker/GamePicker.scss
+++ b/client/src/components/GamePicker/GamePicker.scss
@@ -10,6 +10,7 @@
   scroll-snap-type: x mandatory;
   scroll-padding: 1rem;
   padding: 1rem;
+  align-items: flex-start;
 
   /* Hide scrollbar on Firefox, IE/Edge, and Chrome/Safari */
   scrollbar-width: none;

--- a/client/src/components/GamePicker/GamePicker.scss
+++ b/client/src/components/GamePicker/GamePicker.scss
@@ -11,6 +11,7 @@
   scroll-padding: 1rem;
   padding: 1rem;
   align-items: flex-start;
+  gap: 1rem;
 
   /* Hide scrollbar on Firefox, IE/Edge, and Chrome/Safari */
   scrollbar-width: none;
@@ -24,7 +25,6 @@
   }
 
   &__children {
-    margin-left: calc(var(--width) + var(--gap));
     width: calc(100% - var(--width) - var(--gap));
     flex-shrink: 0;
   }
@@ -32,14 +32,17 @@
 
 .game-picker-item {
   flex: var(--width) 0 0;
-  margin-right: var(--gap);
   scroll-snap-align: start;
   display: grid;
-  transition: margin-right 0.1s;
+  transition: margin-left 0.1s;
   z-index: var(--stackPosition);
 
   &--done {
-    margin-right: calc(-1 * var(--width));
+    scroll-snap-align: none;
+  }
+
+  &--done:not(:first-child) {
+    margin-left: calc(-1 * var(--width) - var(--gap));
   }
 
   &__input {

--- a/client/src/components/GamePicker/GamePicker.scss
+++ b/client/src/components/GamePicker/GamePicker.scss
@@ -11,7 +11,6 @@
   scroll-padding: 1rem;
   padding: 1rem;
   align-items: flex-start;
-  gap: 1rem;
 
   /* Hide scrollbar on Firefox, IE/Edge, and Chrome/Safari */
   scrollbar-width: none;
@@ -36,6 +35,7 @@
   display: grid;
   transition: margin-left 0.1s;
   z-index: var(--stackPosition);
+  margin-right: var(--gap);
 
   &--done {
     scroll-snap-align: none;

--- a/client/src/components/PlayerPicker/PlayerPicker.scss
+++ b/client/src/components/PlayerPicker/PlayerPicker.scss
@@ -10,7 +10,6 @@
 .player-picker-item {
   display: grid;
   animation: player-picker-popin 0.1s;
-  animation-delay: 0.1s;
   animation-fill-mode: both;
 
   &__input {

--- a/client/src/components/WinnerPicker/WinnerPicker.scss
+++ b/client/src/components/WinnerPicker/WinnerPicker.scss
@@ -10,7 +10,6 @@
 .winner-picker-item {
   display: grid;
   animation: winner-picker-popin 0.1s;
-  animation-delay: 0.1s;
   animation-fill-mode: both;
 
   &__input {


### PR DESCRIPTION
Adds a useEffect to hide the "children" (i.e. the player icons) from the GamePicker component until it's done animating. Otherwise, it pops in and makes things janky in certain browsers.
