### PR TITLE
Tests for playerRoutes

### DIFF
--- a/server/controllers/playerController.js
+++ b/server/controllers/playerController.js
@@ -32,11 +32,21 @@ const getSinglePlayer = async (req, res) => {
 };
 
 const addNewPlayer = async (req, res) => {
-  const player = req.body;
+  const { name, points, image_url } = req.body;
+
+  if (!name) {
+    return res.status(400).json({ error: "Required field: name" });
+  }
+
+  const player = {
+    name,
+    points: points ?? null,
+    image_url: image_url ?? null,
+  };
 
   try {
     const newPlayer = await saveNewPlayer(player);
-    res.json(newPlayer);
+    res.status(201).json(newPlayer);
   } catch (error) {
     res.status(500).json({ error: `Error: ${error.message}` });
   }

--- a/server/routes/playerRoutes.test.js
+++ b/server/routes/playerRoutes.test.js
@@ -1,0 +1,100 @@
+import { it, expect, describe, beforeEach } from "vitest";
+import request from "supertest";
+import app from "../index.js";
+import db from "../db/connection.js";
+
+beforeEach(async () => {
+  await db.execute(`DELETE from players`);
+
+  await db.execute(`
+    INSERT INTO players (id, name, points, image_url) VALUES
+      (1, 'Joe', 150, '/example.jpg'),
+      (2, 'Sammy', 150, '/example.jpg'),
+      (3, 'Michael', 0, '/example.jpg');
+  `);
+});
+
+describe("GET /players", () => {
+  it("Responds with a list of all players", async () => {
+    const response = await request(app).get("/players");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        id: 1,
+        name: "Joe",
+        points: 150,
+        image_url: "/example.jpg",
+      },
+      {
+        id: 2,
+        name: "Sammy",
+        points: 150,
+        image_url: "/example.jpg",
+      },
+      {
+        id: 3,
+        name: "Michael",
+        points: 0,
+        image_url: "/example.jpg",
+      },
+    ]);
+  });
+});
+
+describe("GET /players/:id", () => {
+  it("Responds with a single player", async () => {
+    const response = await request(app).get("/players/1");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      id: 1,
+      name: "Joe",
+      points: 150,
+      image_url: "/example.jpg",
+    });
+  });
+});
+
+describe("POST /players", () => {
+  it("Fails given an empty body", async () => {
+    const body = {};
+
+    const response = await request(app).post("/players").send(body);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("Responds with the new player", async () => {
+    const body = {
+      name: "New player",
+    };
+
+    const response = await request(app).post("/players").send(body);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject(body);
+    expect(response.body).toHaveProperty("id");
+    expect(response.body.points).toBe(0);
+    expect(response.body.image_url).toBe(null);
+  });
+
+  it("Creates the new player", async () => {
+    const body = {
+      name: "New player",
+    };
+
+    await request(app).post("/players").send(body);
+    const [databaseRows] = await db.execute(
+      "SELECT name, points, image_url FROM players"
+    );
+
+    const expectedResult = {
+      name: body.name,
+      points: 0,
+      image_url: null,
+    };
+
+    expect(databaseRows).toContainEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
Add endpoint tests for `playerRoutes`

This PR builds on the work in #33, and should be merged after that one.

Again, focusing on just the tests we need before our tech stack switch.